### PR TITLE
开放typeConvert配置项，可以自由配置数据库字段要映射的java字段类型。

### DIFF
--- a/src/main/java/com/github/davidfantasy/mybatisplus/generatorui/ApplicationConfigure.java
+++ b/src/main/java/com/github/davidfantasy/mybatisplus/generatorui/ApplicationConfigure.java
@@ -41,6 +41,7 @@ public class ApplicationConfigure {
         dataSourceConfig.setUsername(config.getUserName());
         dataSourceConfig.setPassword(config.getPassword());
         dataSourceConfig.setSchemaName(config.getSchemaName());
+        dataSourceConfig.setTypeConvert(config.getTypeConvert());
         return dataSourceConfig;
     }
 

--- a/src/main/java/com/github/davidfantasy/mybatisplus/generatorui/GeneratorConfig.java
+++ b/src/main/java/com/github/davidfantasy/mybatisplus/generatorui/GeneratorConfig.java
@@ -1,5 +1,6 @@
 package com.github.davidfantasy.mybatisplus.generatorui;
 
+import com.baomidou.mybatisplus.generator.config.ITypeConvert;
 import com.baomidou.mybatisplus.generator.config.rules.DateType;
 import com.github.davidfantasy.mybatisplus.generatorui.mbp.NameConverter;
 import com.github.davidfantasy.mybatisplus.generatorui.mbp.TemplateVaribleInjecter;
@@ -70,6 +71,11 @@ public class GeneratorConfig {
      * 自定义名称转换规则
      */
     private NameConverter nameConverter;
+
+    /**
+     * 自定义数据字段类型和实体类型映射
+     */
+    private ITypeConvert typeConvert;
 
     public NameConverter getAvailableNameConverter() {
         if (nameConverter == null) {


### PR DESCRIPTION
mbp默认的OracleTypeConvert生成的java字段类型不太理想。
因此增加typeConvert配置项对外开放，方便自由配置数据库字段要映射的java字段类型。

