### PR TITLE
修复选择存在同名文件覆盖但是新的controller文件未覆盖的问题

### DIFF
--- a/src/main/java/com/github/davidfantasy/mybatisplus/generatorui/mbp/MbpGenerator.java
+++ b/src/main/java/com/github/davidfantasy/mybatisplus/generatorui/mbp/MbpGenerator.java
@@ -86,6 +86,9 @@ public class MbpGenerator {
                     configEntity(builder.entityBuilder(), userConfig.getEntityStrategy(), genSetting.isOverride());
                     configMapper(builder.mapperBuilder(), userConfig.getMapperStrategy(), userConfig.getMapperXmlStrategy(), genSetting.isOverride());
                     configService(builder.serviceBuilder(), userConfig.getServiceStrategy(), userConfig.getServiceImplStrategy());
+                    if (genSetting.isOverride()){
+                        configController(builder.controllerBuilder().enableFileOverride(), userConfig.getControllerStrategy());
+                    }
                     configController(builder.controllerBuilder(), userConfig.getControllerStrategy());
                 }).execute();
     }

--- a/src/main/java/com/github/davidfantasy/mybatisplus/generatorui/mbp/MbpGenerator.java
+++ b/src/main/java/com/github/davidfantasy/mybatisplus/generatorui/mbp/MbpGenerator.java
@@ -86,10 +86,11 @@ public class MbpGenerator {
                     configEntity(builder.entityBuilder(), userConfig.getEntityStrategy(), genSetting.isOverride());
                     configMapper(builder.mapperBuilder(), userConfig.getMapperStrategy(), userConfig.getMapperXmlStrategy(), genSetting.isOverride());
                     configService(builder.serviceBuilder(), userConfig.getServiceStrategy(), userConfig.getServiceImplStrategy());
-                    if (genSetting.isOverride()){
+                    if (genSetting.isOverride()) {
                         configController(builder.controllerBuilder().enableFileOverride(), userConfig.getControllerStrategy());
+                    } else {
+                        configController(builder.controllerBuilder(), userConfig.getControllerStrategy());
                     }
-                    configController(builder.controllerBuilder(), userConfig.getControllerStrategy());
                 }).execute();
     }
 


### PR DESCRIPTION
问题：页面上勾选存在同名文件是否覆盖，生成新的Controller文件，生成成功后并未覆盖之前生成的Controller文件。