### PR TITLE
GeneratorConfig 添加 entityStrategy 属性

### DIFF
--- a/src/main/java/com/github/davidfantasy/mybatisplus/generatorui/GeneratorConfig.java
+++ b/src/main/java/com/github/davidfantasy/mybatisplus/generatorui/GeneratorConfig.java
@@ -1,15 +1,13 @@
 package com.github.davidfantasy.mybatisplus.generatorui;
 
-import com.baomidou.mybatisplus.annotation.DbType;
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.generator.config.ITypeConvert;
 import com.baomidou.mybatisplus.generator.config.rules.DateType;
 import com.github.davidfantasy.mybatisplus.generatorui.mbp.NameConverter;
 import com.github.davidfantasy.mybatisplus.generatorui.mbp.TemplateVaribleInjecter;
+import com.github.davidfantasy.mybatisplus.generatorui.strategy.EntityStrategy;
 import lombok.Builder;
 import lombok.Data;
-
-import java.util.Objects;
 
 @Builder
 @Data
@@ -81,6 +79,8 @@ public class GeneratorConfig {
      * 全局指定数据表中ID的生成模式，影响自动生成的Entity中ID字段的注解
      */
     private IdType idType;
+
+    private  EntityStrategy entityStrategy;
 
     public NameConverter getAvailableNameConverter() {
         if (nameConverter == null) {

--- a/src/main/java/com/github/davidfantasy/mybatisplus/generatorui/service/UserConfigStore.java
+++ b/src/main/java/com/github/davidfantasy/mybatisplus/generatorui/service/UserConfigStore.java
@@ -59,6 +59,9 @@ public class UserConfigStore implements InitializingBean {
             userConfig = new UserConfig();
             userConfig.setOutputFiles(getBuiltInFileInfo());
         }
+        if(generatorConfig.getEntityStrategy()!=null){
+            userConfig.setEntityStrategy(generatorConfig.getEntityStrategy());
+        }
         return userConfig;
     }
 


### PR DESCRIPTION
使用户可以精确的设置 EntityStrategy。比如控制他是否生成`Lombok`.
```
entityStrategy.setEntityLombokModel(true);
```
现在我还没办法设置是否开启 `Lombok`,故提交次PR